### PR TITLE
[VaccinTracker] Ne pas utiliser des balises `button` pour les éléments qui ne sont pas des actions.

### DIFF
--- a/src/VaccinTracker/autorisations.php
+++ b/src/VaccinTracker/autorisations.php
@@ -3,7 +3,7 @@
     L'Union Européenne a passé des commandes pour 6 vaccins différents. 2 sont autorisés, et 4 n'ont pas encore été soumis. <i>Mise à jour : 06/12.</i><br><br>
     <h3 style="margin-top : 10px;">Vaccins autorisés</h3>
     <div class="row">
-        <button class="shadow-btn-green  col-xs-11 col-md-4"><b>🇺🇸🇩🇪 Pfizer-BioNTech</b><br>
+        <card class="shadow-btn-green col-xs-11 col-md-4"><b>🇺🇸🇩🇪 Pfizer-BioNTech</b><br>
             Type : ARN messager<br>
             Efficacité annoncée : 94.5%<br>
             Conservation : -70°C<br>
@@ -11,9 +11,9 @@
             Dont France : 75M + 15M<br>
             Doses à injecter : 2<br>
             Statut : autorisé (UE, France)
-        </button>
+        </card>
 
-        <button class="shadow-btn-green  col-xs-11 col-md-4"><b>🇺🇸 Moderna</b><br>
+        <card class="shadow-btn-green col-xs-11 col-md-4"><b>🇺🇸 Moderna</b><br>
             Type : ARN messager<br>
             Efficacité annoncée : 94%<br>
             Conservation : -20°C (6 mois), +5°C (1 mois)<br>
@@ -21,12 +21,12 @@
             Dont France : 24M<br>
             Doses à injecter : 2<br>
             Statut : autorisé (UE, France)
-        </button>
+        </card>
     </div>
 
     <h3 style="margin-top : 50px;">Vaccins en cours d'autorisation</h3>
     <div class="row">
-        <button class="shadow-btn  col-xs-11 col-md-4"><b>🇬🇧🇸🇪 AstraZeneca/Oxford</b><br>
+        <card class="shadow-btn col-xs-11 col-md-4"><b>🇬🇧🇸🇪 AstraZeneca/Oxford</b><br>
             Phase 3/3<br>
             Type : Vecteur viral<br>
             Efficacité annoncée : 70%<br>
@@ -34,28 +34,28 @@
             Commandes UE : 300M (+ option 100M)<br>
             Doses à injecter : 2<br>
             Statut : décision UE 29/01
-        </button>
+        </card>
     </div>
 
     <h3 style="margin-top : 50px;">Vaccins pas encore soumis</h3>
     <div class="row">
-        <button class="shadow-btn col-xs-11 col-md-4"><b>🇺🇸🇧🇪 Janssen J&J</b><br>
+        <card class="shadow-btn col-xs-11 col-md-4"><b>🇺🇸🇧🇪 Janssen J&J</b><br>
             Phase 3/3<br>
             Type : Vecteur viral<br>
             Efficacité annoncée : --%<br>
             Prêt : fin janvier 2021<br>Conservation : +5°C<br>Commandes UE : 200M (+ option 200M)<br>Doses à injecter : 1 (essai en cours) ou 2<br>Statut : --
-        </button>
-        <button class="shadow-btn col-xs-11 col-md-4"><b>🇩🇪 CureVac</b><br>
+        </card>
+        <card class="shadow-btn col-xs-11 col-md-4"><b>🇩🇪 CureVac</b><br>
             Phase 2/3<br>
             Type : ARN messager<br>
             Efficacité annoncée : --%<br>
             Prêt : 1er semestre 2021<br>Conservation : -60°C (3 mois), +5°C (3 mois)<br>Commandes UE : 225M (+ option 180M)<br>Doses à injecter : 2<br>Statut : --
-        </button>
-        <button class="shadow-btn col-xs-11 col-md-4"><b>🇫🇷🇬🇧 Sanofi/Pasteur-GSK</b><br>
+        </card>
+        <card class="shadow-btn col-xs-11 col-md-4"><b>🇫🇷🇬🇧 Sanofi/Pasteur-GSK</b><br>
             Phase 2/3<br>
             Type : Protéines virales<br>
             Efficacité annoncée : --%<br>
             Prêt : fin 2021<br>Conservation : +5°C<br>Commandes UE : 300M<br>Doses à injecter : --<br>Statut : --
-        </button>
+        </card>
     </div>
 </div>

--- a/src/VaccinTracker/vaccintrackerStyles.php
+++ b/src/VaccinTracker/vaccintrackerStyles.php
@@ -18,6 +18,17 @@ button {
 
 }
 
+card {
+    border: 1px solid;
+    margin: 10px;
+    padding: 15px;
+    font-size : 16px;
+    transition-duration: 0.4s;
+    background-color: #ffffff;
+    border-radius: 15px;
+
+}
+
 /* the flex container without mediaquerie */
 
 div[class_perso] {


### PR DESCRIPTION
## Problème

Sur la page https://covidtracker.fr/vaccintracker/, les différentes cartes sont rendues avec des balises `button`.
Cela peut porter à confusion les utilisateurs qui peuvent penser qu'une action est possible au clic sur cette carte.
De plus, les personnes en situation de handicap utilisant un lecteur d'écran auront une compréhension erronée de la structure de la page, rendant la navigationpeu aisée.

## Solution

Utiliser la balise `card`, tout en respectant le style existant (ombrages verts notamment).