### PR TITLE
[DOC] Ajout d'un fichier `docker-compose` et de sa documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # covidtracker-tools
 Ce dépôt contient les sources de quelques pages de CovidTracker.fr, notamment les outils.
 Dépôt concernant la gestion des données et graphiques : [covid-19](https://github.com/rozierguillaume/covid-19).
+
+# Afficher le VaccinTracker dans l'environnement de développement (local)
+
+## Pré-requis
+[Docker](https://docs.docker.com/get-docker/)
+
+## Mode opératoire
+
+Afin de faciliter le développement, il est possible de lancer VaccingTracker sur une machine locale.
+Pour cela, il faut lancer la commande
+```bash
+docker-compose up -d
+```
+
+Les modifications locales sont alors accessibles à l'adresse http://localhost:8100/VaccinTracker/test.php.
+:warning: Les modifications n'entrainent pas un rechargement automatique de la page we. Il faut penser à la rafraîchir manuellement.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+
+services:
+  web:
+    image: php:8.0.1-apache
+    restart: always
+    container_name: php_web
+    volumes:
+      - ./src:/var/www/html/
+    ports:
+      - "8100:80"
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
# Problème

Il n'est pas évident pour une personne souhaitant contribuer de savoir comment tester ses modifications localement.

# Solution

Un fichier `test.php` est déjà disponible mais il nécessite d'avoir un server apache permettant son interprétation.
Je propose donc d'ajouter un fichier `docker-compose` permettant de démarrer un server apache avec une simple commande et sans installation préalable (si ce n'est docker lui-même).
L'usage du fichier `docker-compose.yml` est documenté dans le `README` du projet pour être visible par le plus grand nombre.