### PR TITLE
Corriger le problème du bouton déselectionner tout

### DIFF
--- a/src/DashboardDepartement2/dashboard-department.php
+++ b/src/DashboardDepartement2/dashboard-department.php
@@ -420,7 +420,7 @@
 
             $('#unselectAll').click(function () {
                 $("#listeDepartements option").each(function () {
-                    $(this).attr('selected', false);
+                    $(this).prop('selected', false);
                 });
                 $("#listeDepartements").trigger('change');
                 $('.departement').remove();
@@ -441,8 +441,8 @@
                 //Sélection des toutes les options du select.
                 $("#listeDepartements option").each(function () {
                     nomDepartement = $(this).val();
-                    if (!$(this).attr('selected')) {
-                        $(this).attr('selected', true);
+                    if (!$(this).prop('selected')) {
+                        $(this).prop('selected', true);
                         if ($("#listeDepartements").val()) {
                             $("#listeDepartements").val($.merge([nomDepartement], $("#listeDepartements").val()));
                         } else {


### PR DESCRIPTION
Dans le code source, il était utilisé `attr` et `prop` pour setté la propriété "selected" d'un département. Cela avait pour conséquence de laisser dans la liste de département selectionné des départements lorsqu'on appuyait sur le bouton "déselectionner tout". Ce commit unifie donc cela en utilisant partout `prop`.