### PR TITLE
Decode vaccination center map as UTF-8

### DIFF
--- a/src/VaccinTracker/vaccin-map.html
+++ b/src/VaccinTracker/vaccin-map.html
@@ -124,7 +124,7 @@ Carte des centres de vaccination. Source des données : Santé.fr.
     let request = fetch(url)
     .then(response => response.arrayBuffer())
     .then(buffer => {
-        let decoder = new TextDecoder("iso-8859-1");
+        let decoder = new TextDecoder();
         let csv = decoder.decode(buffer);
         //console.log(text)
         data_array = CSVToArray(csv, ";");

--- a/src/VaccinTracker/vaccin-map.html
+++ b/src/VaccinTracker/vaccin-map.html
@@ -126,20 +126,19 @@ Carte des centres de vaccination. Source des données : Santé.fr.
     .then(buffer => {
         let decoder = new TextDecoder();
         let csv = decoder.decode(buffer);
-        //console.log(text)
         data_array = CSVToArray(csv, ";");
           
-          data_array.slice(1, data_array.length-1).map((value, idx) => {
-            longitudes.push(value[9])
-            latitudes.push(value[10])
-            noms.push(value[1])
-            reservation.push(value[32])
-            date_ouverture.push(value[31])
-            rdv_tel.push(value[33])
-            modalites.push(value[34])
-            adresses.push(value[4] + " " + value[5] + ", " + value[6] + " " + value[8])
-            maj.push(value[19].slice(0, 16))
-          })
+        data_array.slice(1, data_array.length-1).map((value, idx) => {
+          longitudes.push(value[9])
+          latitudes.push(value[10])
+          noms.push(value[1])
+          reservation.push(value[32])
+          date_ouverture.push(value[31])
+          rdv_tel.push(value[33])
+          modalites.push(value[34])
+          adresses.push(value[4] + " " + value[5] + ", " + value[6] + " " + value[8])
+          maj.push(value[19].slice(0, 16))
+        })
 
           ajouter_pins();
     })
@@ -158,8 +157,6 @@ Carte des centres de vaccination. Source des données : Santé.fr.
 
     
     function ajouter_pins(){
-        console.log("debut")
-        
         latitudes.map((lat, idx)=>{
             var reservation_str = ""
             if (reservation[idx].slice(0, 4)=="http"){
@@ -177,7 +174,6 @@ Carte des centres de vaccination. Source des données : Santé.fr.
 
         })
         mymap.addLayer(markers);
-        console.log("fin")
     }
     
 </script>

--- a/src/VaccinTracker/vaccin-map.html
+++ b/src/VaccinTracker/vaccin-map.html
@@ -148,29 +148,6 @@ Carte des centres de vaccination. Source des données : Santé.fr.
            console.log("error1")
        });
 
-    var myHeaders = new Headers();
-    myHeaders.append('Content-Type','text/csv;charset=utf-8'); //iso-8859-1
-
-    fetch('https://www.data.gouv.fr/fr/datasets/r/5cb21a85-b0b0-4a65-a249-806a040ec372', {headers: myHeaders, cache: 'no-cache'})
-       .then(response => {
-           if (!response.ok) {
-               throw new Error("HTTP error " + response.status);
-           }
-           return response.text();
-       })
-       .then(csv => {
-           
-          this.data = csv;
-          data_array = CSVToArray(csv, ";");
-          
-        })
-       .catch(function () {
-           this.dataError = true;
-           console.log("error1")
-       }
-      )
-//
-
     var mymap = L.map('mapid').setView([46.505, 3], 6);
     var markers = L.markerClusterGroup();
 


### PR DESCRIPTION
Decode vaccination center as UTF-8 instead of ISO-8859-1, to correctly format unicode characters (`TextDecoder` default encoding is `utf-8`, see https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/TextDecoder#parameters).

Also remove an unnecessary second request made to the dataset that basically does nothing, apart from populating `data_array`, but this is already done by the first HTTP request.

Before (using ISO-8869-1 encoding):
![Screenshot from 2021-01-19 23-55-39](https://user-images.githubusercontent.com/5970971/105105591-a7289580-5ab4-11eb-813c-e0e7845700a5.png)
After (using UTF-8 encoding):
![Screenshot from 2021-01-20 00-15-35](https://user-images.githubusercontent.com/5970971/105105599-aabc1c80-5ab4-11eb-965f-9528009f93da.png)
