### PR TITLE
Delete extra line in the list of authorized vaccines

### DIFF
--- a/src/VaccinTracker/autorisations.php
+++ b/src/VaccinTracker/autorisations.php
@@ -26,7 +26,7 @@
             Phase 3/3<br>
             Type : Vecteur viral<br>
             Efficacité annoncée : 60-70% (moins de 55 ans)<br>
-            Prêt : fin 2020<br>Conservation : +5°C (6 mois)<br>
+            Conservation : +5°C (6 mois)<br>
             Commandes UE : 300M (+ option 100M)<br>
             Doses à injecter : 2<br>
             Statut : autorisé UE (29/01)


### PR DESCRIPTION
Hello,

The list of authorized vaccinees no longer has a mention of when they will be ready. The latest authorized vaccine still has this mention.