### PR TITLE
Mise à jour légende de l'évolution de cumul de vaccination

### DIFF
--- a/src/VaccinTracker/vaccintrackerJs.php
+++ b/src/VaccinTracker/vaccintrackerJs.php
@@ -346,7 +346,7 @@
                         steppedLine: true,
                     },
                     {
-                        label: 'Cumul vaccinés (1 ou 2 doses) ',
+                        label: 'Cumul vaccinés (1 dose) ',
                         data: data_values,
                         borderWidth: 3,
                         backgroundColor: '#a1cbe6',


### PR DESCRIPTION
"Cumul vaccinés (1 ou 2 doses)" semble ne pas correspondre aux données affichées. Il semblerait que la courbes affiche les premières injections et non l'addition des premières et secondes injections. 
Légende renommée en "Cumul vaccinés (1 dose)".