### PR TITLE
Dataexplorer: make checkbox labels clickable

### DIFF
--- a/src/DataExplorer/dataexplorer.php
+++ b/src/DataExplorer/dataexplorer.php
@@ -49,7 +49,12 @@ Lors du lancement de VaccinTracker le 27 décembre (jour du début de la campagn
             <div id="checkboxes" style="text-align: left; overflow-y:scroll; padding: 10px; border-radius: 7px; height: 550px; box-shadow: inset 0px 0px 10px 5px rgba(0, 0, 0, 0.07)">
                 
                 
-                    <input type='checkbox' id='france' checked onchange="boxChecked('france')"> France<br>
+                    <div class="checkbox">
+                        <label>
+                            <input type='checkbox' id='france' checked onchange="boxChecked('france')">France
+                        </label>
+                    </div>
+                    <br>
                     <span id="territoiresCheckboxes"></span>
                 
             </div>

--- a/src/DataExplorer/dataexplorer.php
+++ b/src/DataExplorer/dataexplorer.php
@@ -126,7 +126,7 @@ function populateTerritoireSelect(){
     var html_code = "";
     html_code += "<br><i>Régions</i><br>"
     data.regions.map((region, idx) => {
-        html_code += "<input type='checkbox' id='" + replaceBadCharacters(region) + "' onchange='boxChecked(\"" + replaceBadCharacters(region) +"\")'> "+ region +"<br>"
+        html_code += "<div class='checkbox'><label>" + "<input type='checkbox' id='" + replaceBadCharacters(region) + "' onchange='boxChecked(\"" + replaceBadCharacters(region) +"\")'> "+ region + "</label></div>" + "<br>"
 
     })
     html_code += "<br><i>Départements</i><br>"
@@ -137,7 +137,7 @@ function populateTerritoireSelect(){
             complement += data["departements_noms"][departement];
         }
 
-        html_code += "<input type='checkbox' id='" + replaceBadCharacters(departement) + "' onchange='boxChecked(\"" + replaceBadCharacters(departement) +"\")'> "+ departement + complement +"<br>"
+        html_code += "<div class='checkbox'><label>" + "<input type='checkbox' id='" + replaceBadCharacters(departement) + "' onchange='boxChecked(\"" + replaceBadCharacters(departement) +"\")'> "+ departement + complement + "</label></div>" + "<br>"
 
     })
 
@@ -269,3 +269,9 @@ function buildEmptyChart() {
 
 
 </script>
+<style type="text/css">
+    .checkbox {
+        margin-top: 0px;
+        margin-bottom: 0px;
+    }
+</style>


### PR DESCRIPTION
## Description

Change légèrement le markup html pour les checkboxes de l'outil DataExplorer, pour que les utilisateurs puissent cliquer sur le nom des régions / départements pour les sélectionner, au lieu de devoir cliquer sur la checkbox uniquement.

## Demo

#### Sur cette branche:
![covidtracker checkboxes](https://user-images.githubusercontent.com/5139869/107163628-9ef1b500-69e5-11eb-93d1-66273b72a2e7.gif)



#### Sur la branche main:

![covidtracker checkboxes main](https://user-images.githubusercontent.com/5139869/107163630-a1540f00-69e5-11eb-8621-46411a8e11d8.gif)
