### PR TITLE
Fix buggy sorting in dataexplorer_table.php

### DIFF
--- a/src/DataExplorer/dataexplorer_table.php
+++ b/src/DataExplorer/dataexplorer_table.php
@@ -414,7 +414,8 @@ function sortTable(idxToSort, order) {
     lastsort = idxToSort
     lastorder = order
 
-    if(lastorder=="asc"){
+    // Down arrow is supposed to be for descending order I guess, grom highest to lowest
+    if(lastorder=="desc"){
         document.getElementById('col'+'0').innerHTML = "▽"
         document.getElementById('col'+'1').innerHTML = "▽"
         document.getElementById('col'+'2').innerHTML = "▽"
@@ -429,65 +430,39 @@ function sortTable(idxToSort, order) {
     }
     
 
-  var table, rows, switching, i, x, y, shouldSwitch;
-  table = document.getElementById("myTable");
-  //console.log(table.innerHTML)
-  switching = true;
-  /*Make a loop that will continue until
-  no switching has been done:*/
-  var j = 0
-  while (switching) {
-    //start by saying: no switching is done:
-    switching = false;
-    rows = table.rows;
-    //console.log(rows)
-    /*Loop through all table rows (except the
-    first, which contains table headers):*/
-    for (i = 1; i < (rows.length - 1); i++) {
-      //start by saying there should be no switching:
-      shouldSwitch = false;
-      /*Get the two elements you want to compare,
-      one from current row and one from the next:*/
-      x = rows[i].getElementsByTagName("TD")[idxToSort];
-      y = rows[i + 1].getElementsByTagName("TD")[idxToSort];
-      //check if the two rows should switch place:
-      assess=false
+    var table, rows, x, y;
+    table = document.getElementById("myTable");
 
-      if(idxToSort>0){
-        if(order=="desc"){
-            //console.log("___")
-            //console.log(idxToSort)
-            //console.log(x.getElementsByTagName('span')[1].innerHTML)
 
-            assess = (parseInt(x.getElementsByTagName('span')[1].innerHTML.toLowerCase()) > parseInt(y.getElementsByTagName('span')[1].innerHTML.toLowerCase()))
-        } else if(order=="asc") {
-            assess = (parseInt(x.getElementsByTagName('span')[1].innerHTML.toLowerCase()) < parseInt(y.getElementsByTagName('span')[1].innerHTML.toLowerCase()))
-        }
-      } else if(idxToSort==0){
-        if(order=="desc"){
-            //assess = (parseInt(x.innerHTML.toLowerCase()) < parseInt(y.innerHTML.toLowerCase()))
-            assess = (('' + x.getElementsByTagName('span')[0].innerHTML).localeCompare(y.getElementsByTagName('span')[0].innerHTML))
-            assess = (assess == 1)
-        } else if(order=="asc") {
-            //assess = (parseInt(x.innerHTML.toLowerCase()) > parseInt(y.innerHTML.toLowerCase()))
-            assess = (('' + y.getElementsByTagName('span')[0].innerHTML).localeCompare(x.getElementsByTagName('span')[0].innerHTML))
-            assess = (assess == 1)
-        }
-      }
-      if (assess==true) {
-        //if so, mark as a switch and break the loop:
-        shouldSwitch = true;
-        break;
-      }
-    }
 
-    if (shouldSwitch) {
-      /*If a switch has been marked, make the switch
-      and mark that a switch has been done:*/
-      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
-      switching = true;
-    }
-  }
+ 	function compareRows(row1,row2) {
+	    x = row1.getElementsByTagName("TD")[idxToSort];
+	    y = row2.getElementsByTagName("TD")[idxToSort];
+        
+	    if(idxToSort > 0){
+            // Put back decimal point and use ParseFloat
+	    	x = parseFloat(x.getElementsByTagName('span')[1].innerHTML.toLowerCase().replace(",","."));
+	    	y = parseFloat(y.getElementsByTagName('span')[1].innerHTML.toLowerCase().replace(",","."));
+	    	if(x == NaN) return 1;
+	    	if(y == NaN) return -1;
+
+	        if(order == "desc")
+	           return y - x;
+	        else if(order == "asc")
+	            return x - y;
+	    }
+	    else if(idxToSort == 0) {
+		    if(order == "desc")
+		     	return (('' + y.getElementsByTagName('span')[0].innerHTML).localeCompare(x.getElementsByTagName('span')[0].innerHTML));
+		    else if(order == "asc")
+		    	return (('' + x.getElementsByTagName('span')[0].innerHTML).localeCompare(y.getElementsByTagName('span')[0].innerHTML));
+		        
+		}	
+	}		
+
+    // Used built-it javascript sort function instead of risking using a handwritten algorithm that might have mistakes
+    rows = Array.from(table.rows).slice(1);
+    rows.sort(compareRows).forEach(function(r) {r.parentNode.appendChild(r);});
 }
 </script>
 


### PR DESCRIPTION
Table sorting had errors : 
- Current Live version uses parseInt to sort values so don't sort numbers that have the same integer part
![image](https://user-images.githubusercontent.com/6672352/112771446-42496880-902c-11eb-9cad-bf39d416f9b7.png)

- At least on today's (03/28) values, had some weird bug : when sorting by ascending weekly growth, Mayotte's -60,5% and St-Pierre-et-Miquelon's -100,0% were somewhere in the middle and seemed to cause some reset in the sorting as further down the values seemed in the correct order. Same thing when changing the order around Moselle's +0,00.  Didn't want to debug the custom sorting algorithm so I used javascript's Array.sort() function. Works like a charm and even seems to improve performance.

![image](https://user-images.githubusercontent.com/6672352/112771461-57be9280-902c-11eb-9b8c-fb652d435ed9.png)
