### PR TITLE
Vaccins dans le monde : remplacer "total doses per 100" par "% with at least 1 dose"

### DIFF
--- a/src/VaccinTracker/dansLeMonde.php
+++ b/src/VaccinTracker/dansLeMonde.php
@@ -1,8 +1,7 @@
 <h2 style="margin-top : 80px;">Vaccination dans le monde</h2>
 
-Ce graphique présente le nombre de doses administrées pour 100 personnes de chaque habitant. Pour la plupart des
-vaccins, 2 doses sont nécessaires. L'immunité collective serait atteinte à partir d'environ 120 doses pour 100 habitants.
-<iframe src="https://ourworldindata.org/grapher/covid-vaccination-doses-per-capita?tab=chart&stackMode=absolute&time=latest&region=World" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>
+Ce graphique présente la part de la population totale de chaque pays ayant reçu au moins une dose de vaccin. Pour la plupart des vaccins, 2 doses sont nécessaires. L'immunité collective serait atteinte à partir d'environ 60%.
+<iframe src="https://ourworldindata.org/grapher/share-people-vaccinated-covid?time=latest&country=BHR~BRA~CHL~DEU~HUN~IND~ISR~RUS~SRB~TUR~GBR~USA~URY~FRA~ESP~BEL~CHE~ITA~European+Union~OWID_WRL" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>
 <br>
 <br>
 Ce graphique présente le nombre de doses administrées dans chaque pays.


### PR DESCRIPTION
Avec l'arrivée des vaccins à 1 dose (J&J) et les preuves de plus en plus solides que la première dose confère une grande partie de la protection, notre communication chez @OWID se focalise davantage sur "people with at least 1 dose" plutôt que "total doses administered". Cette métrique présente aussi l'avantage d'être plus facile à comprendre (par opposition à "total doses per 100 people" qui finit par aller au-delà de 100).