### PR TITLE
Correction sur le slider de DéconfiTracker

### DIFF
--- a/src/DeconfiTracker/index.html
+++ b/src/DeconfiTracker/index.html
@@ -301,7 +301,7 @@ function buildNoUiSlider(){
         connect: true,
         step: 1,
         range: {
-            'min': 0,
+            'min': 1,
             'max': 50,
         }
     });


### PR DESCRIPTION
Le slider de DéconfiTracker, lorsque mis à 0, provoquait l'affichage de "NaN / 5 000 projection des cas quotidiens dans 0 jours à croissance constante", ce qui n'a pas de sens. Je l'ai corrigé pour lui affecter 1 comme valeur minimale possible.