### PR TITLE
Preuve de concept: sections avec id, pour lien vers sections

### DIFF
--- a/src/DashboardFrance/dashboard-france.php
+++ b/src/DashboardFrance/dashboard-france.php
@@ -36,7 +36,9 @@ Les données sont issues de Santé Publique France et l’INSEE. <i>Mise à jour
 </div>
 
 
-<?php include(__DIR__ . '/vueDEnsemble.php') ?>
+<section id="vue-ensemble">
+  <?php include(__DIR__ . '/vueDEnsemble.php') ?>
+</section>
 
 <div class="alert alert-info clearFix" style="font-size: 18px; margin-top:10px; margin-bottom:40px;">
     <div class="row">
@@ -55,12 +57,22 @@ Les données sont issues de Santé Publique France et l’INSEE. <i>Mise à jour
         </div>
     </div>
 </div>
-<?php include(__DIR__ . '/activite.php') ?>
-<?php include(__DIR__ . '/indicateursEpidemiques.php') ?>
-<?php include(__DIR__ . '/hospitalisationsEtReanimations.php') ?>
-<?php include(__DIR__ . '/deces.php') ?>
-<?php include(__DIR__ . '/mortalite.php') ?>
-<?php include(__DIR__ . '/footer.php') ?>
 
-
-
+<section id="activité">
+  <?php include(__DIR__ . '/activite.php') ?>
+</section>
+<section id="indicateurs-épidémiques">
+  <?php include(__DIR__ . '/indicateursEpidemiques.php') ?>
+</section>
+<section id="hospitalisations-réanimations">
+  <?php include(__DIR__ . '/hospitalisationsEtReanimations.php') ?>
+</section>
+<section id="décès">
+  <?php include(__DIR__ . '/deces.php') ?>
+</section>
+<section id="mortalité">
+  <?php include(__DIR__ . '/mortalite.php') ?>
+</section>
+<section id="footer">
+  <?php include(__DIR__ . '/footer.php') ?>
+</section>


### PR DESCRIPTION
PR en cours de construction

But: pouvoir pointer par lien vers des parties spécifiques d'une page.

Plan d'action:
- ajouter des `id` aux bons endroits
  - soit directement sur les headings h2, h3...
  - soit en ajoutant des `<section id="activité">...</section>` autour des blocs logiques (souvent des include php il semblerait) (c'est ce qui est par exemple recommandé par https://developers.google.com/style/headings-targets)
- dans un premier temps les connaisseurs peuvent trouver ces id et fabriquer à la main des URLs pointant vers la section. Par exemple avec un id déjà existant : https://covidtracker.fr/#carte
  (mais qui montre ses limites: le haut du bloc est masqué par le header statique; ajouter une section semble aider car elle rajoute une marge)
- dans un second temps rendre ces liens visibles à tout le monde, peut-être avec une petite icone cliquable sur les headings comme fait ici: https://css-tricks.com/how-to-section-your-html/#contents ?
- enfin, généraliser aux structures complexes: les vues avec tab, les différentes configurations d'affichage dynamique (menus déroulants, checkboxes..) toujours dans le but de pouvoir partager un bout précis d'une page du site.

Ce premier commit est une preuve de concept: si ça vous va je me propose de faire une première version où je rajoute des sections partout.

p.s. le développement frontend n'est clairement pas ma spécialité, je suis preneur de toute remarque, suggestion, aide ou carrément reprise en main de cet effort par quelqu'un de plus compétent que moi.