### PR TITLE
Fix VaccinPlanner

### DIFF
--- a/src/VaccinPlanner/vaccinplanner.php
+++ b/src/VaccinPlanner/vaccinplanner.php
@@ -581,7 +581,7 @@ function fetchOtherData(){
                     nb_vaccines.push({
                         date: value,
                         heure: "19h30",
-                        total: data["n_dose1_cumsum"][idx],
+                        total: data["n_cum_dose1"][idx],
                         source: "Ministère de la santé"
                     });
                 })


### PR DESCRIPTION
In [this commit](https://github.com/rozierguillaume/vaccintracker/commit/d6105a6b556fa171fb98422888278392c68dad00#diff-e406847aedb481feea7bcfeef82df80c15abd40821c279662e9a7c79ce6ef878), you renamed `n_dose1_cumsum` into `n_cum_dose1`, which broke the code used in VaccinPlanner.

This fixes #267 