### PR TITLE
Use French people who can be vaccinated

### DIFF
--- a/src/VaccinTracker/immuniteCollective.php
+++ b/src/VaccinTracker/immuniteCollective.php
@@ -1,8 +1,7 @@
 <h2 style="margin-top: 40px;">
     Quand l'immunité collective sera-t-elle atteinte ?
 </h2>
-Sur VaccinTracker, le taux de 60% a été choisi comme seuil d'immunité collective. Cependant, on ne peut pas
-aujourd'hui connaître ce taux précisément.
+Nous ne pouvons pas aujourd'hui connaître le taux à atteindre pour bénéficier de l'immunité.
 La vidéo suivante du média Le Monde explique très bien la problématique à notre sens :
 <br><br>
 <div class="videoWrapper">

--- a/src/VaccinTracker/proportionVaccines.php
+++ b/src/VaccinTracker/proportionVaccines.php
@@ -2,8 +2,8 @@
 <h2 style="margin-top : 80px;">Proportion de personnes vaccinées</h2>
 Chaque carré correspond à 1% des Français.
 Les carrés vert foncé <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill:rgb(31, 128, 57);" /></svg> correspondent aux Français complètement vaccinées
-et les carrés vert clair <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill:rgb(45, 189, 84);" /></svg> aux Français ayant commencé leur vaccination. Les carrés rouge vif <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill:rgb(237, 88, 88);" /></svg> représentent les Français qu'il faut vacciner avant d'atteindre un taux de vaccination de 60%.
-Les carrés rouge clair <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill: rgb(207, 169, 169);" /></svg>  représentent les autres Français non vaccinés. <i>Mise à jour : <span id="date_maj_3">--/--</span></i>
+et les carrés vert clair <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill:rgb(45, 189, 84);" /></svg> aux Français ayant commencé leur vaccination. Les carrés rouge vif <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill:rgb(237, 88, 88);" /></svg> représentent les Français non vacinnés pour lesquels un vaccins homologué existe.
+Les carrés rouge clair <svg width="10" height="10"><rect x="0" y="0" width="60" height="60" style="fill: rgb(207, 169, 169);" /></svg> représentent les Français de moins de 16 ans pour lesquels aucun vaccin n'est aujourd'hui homologué. <i>Mise à jour : <span id="date_maj_3">--/--</span></i>
 
 
 <div class="row">
@@ -15,10 +15,7 @@ Les carrés rouge clair <svg width="10" height="10"><rect x="0" y="0" width="60"
     <br>
     <div class="col-md-4" style="padding-top: 20px;">
         <span style="font-size: 200%; color: rgb(45, 189, 84)"><span id="proportionVaccinesMax">--</span>%</span><br> des Français ont reçu au moins une dose de vaccin, <span style="color: rgb(31, 128, 57)"><span id="proportionVaccinesTotalement">--</span>%</span> ont reçu toutes les doses requises.<br><br>
-        Il reste à vacciner au moins <br><span style="font-size: 200%; color: rgb(237, 88, 88);"><span id="proportionAVaccinerImmu">--</span>%</span><br>des Français avant d'atteindre un taux de vaccination de 60%. <br><br>
-        <span style="font-size: 80%;">
-            N.B. : un taux de vaccination de 60% ne permet pas nécessairement d'atteindre une immunité collective.<br>
-        </span>
+        Il reste <br><span style="font-size: 200%; color: rgb(237, 88, 88);"><span id="proportionVaccinable">--</span>%</span><br>des Français pouvant bénéficier d'un vaccin homologué. <br><br>
     </div>
 </div>
 <br>

--- a/src/VaccinTracker/vaccintrackerJs.php
+++ b/src/VaccinTracker/vaccintrackerJs.php
@@ -125,6 +125,7 @@
     const OBJECTIF_FIN_JANVIER = 1000000 // 1_000_000
     const OBJECTIF_FIN_AOUT = 52000000 // 1_000_000
     const OBJECTIF_MI_JUIN = 30000000
+    const PART_FRANCAIS_VACCINABLE = 81.2 // français >= 16 ans (vaccin homologué), src : https://www.insee.fr/fr/statistiques/3312958
     var data;
     var data_france;
     var nb_vaccines = [];
@@ -134,7 +135,7 @@
     let differentielVaccinesParJour;
     var dejaVaccinesNb;
     var dejaVaccines = 0;
-    var restantaVaccinerImmunite;
+    var restantaVaccinable;
     var restantaVaccinerAutres = 100
     var objectifQuotidien;
     var dateProjeteeObjectif;
@@ -240,7 +241,7 @@
                 nb_vaccines = nb_vaccines.sortBy('date'); // tri par date
                 dejaVaccinesNb = nb_vaccines[nb_vaccines.length - 1].n_dose1
                 dejaVaccines = dejaVaccinesNb * 100 / 67000000;
-                restantaVaccinerImmunite = 60 - dejaVaccines
+                restantaVaccinable = PART_FRANCAIS_VACCINABLE - dejaVaccines
                 this.objectifQuotidien = calculerObjectif();
                 fetch2ndDosesData();
 
@@ -1041,7 +1042,7 @@
                             newsubrow.classList.add('green');
                         } else if (caseNb <= proportionVaccinesPartiellement + 0.01) {
                             newsubrow.classList.add('animation-premiere-dose');
-                        } else if (caseNb <= 60) {
+                        } else if (caseNb <= PART_FRANCAIS_VACCINABLE) {
                             newsubrow.classList.add("red");
                         } else {
                             newsubrow.classList.add("grey");
@@ -1097,7 +1098,7 @@
         //document.getElementById("proportionVaccinesMin").innerHTML = (Math.round(dejaVaccines/2*10000000)/10000000).toFixed(2);
         //document.getElementById("proportion_doses").innerHTML = (dejaVaccinesNb/cumul_stock*100).toFixed(1);
 
-        document.getElementById("proportionAVaccinerImmu").innerHTML = (Math.round(restantaVaccinerImmunite * 10000000) / 10000000).toFixed(2);
+        document.getElementById("proportionVaccinable").innerHTML = (Math.round(restantaVaccinable * 10000000) / 10000000).toFixed(2);
         document.getElementById("objectif_quotidien").innerHTML = numberWithSpaces(objectifQuotidien);
         document.getElementById("date_projetee_objectif").innerHTML = formaterDate(dateProjeteeObjectif);
         date = nb_vaccines[nb_vaccines.length - 1].date


### PR DESCRIPTION
Le seuil d'immunité de 60% est hautement théorique et n'a aujourd'hui plus de sens avec les différents variants en circulation.

Je propose de le remplacer par les part des français pour lesquels il existe un vaccin homologué (>= 16 ans aujourd'hui)