### PR TITLE
Proposition : Changement de couleur de l'échelle du taux de vaccination par département

### DIFF
--- a/src/VaccinTracker/carteDepartementJs.php
+++ b/src/VaccinTracker/carteDepartementJs.php
@@ -18,7 +18,7 @@
         var typeCarteDepartement = 'n_dose1_cumsum_pop';
         var dateMaj = "";
 
-        var tableauValeurs = [">", "42", "39", "36", "33", "30", "24", "20", "10", "5"];
+        var tableauValeurs = [">", "53", "50", "47", "44", "41", "38", "35", "25", "15"];
         var tableauCouleurs = [
             "#0076bf",
             "#1796e6",


### PR DESCRIPTION
Hello,

Je propose un changement d'échelle, vu que cela devient tout bleu : 
![image](https://user-images.githubusercontent.com/472429/121863034-b6c2a800-ccfb-11eb-9826-3e00eb09e292.png)

Donc j'ai commencer à 15 (pour les DOM-TOM) puis de 10 en 10 juste 35
puis de 4 en 4 jusque 58