### PR TITLE
Echelle automatique pour la carte des vaccinnés découpés par déciles

### DIFF
--- a/src/VaccinTracker/carteDepartementJs.php
+++ b/src/VaccinTracker/carteDepartementJs.php
@@ -97,6 +97,33 @@
             return sign*y;
         }
 
+        function computeDeciles() {
+            let percentages = [];
+            for (numeroDepartement in donneesDepartementsVaccination) {
+                if (numeroDepartement == 'departements') {
+                    continue;
+                }
+                percentages.push(donneesDepartementsVaccination[numeroDepartement]["n_dose1_cumsum_pop"]);
+            }
+            percentages = percentages.sort();
+
+            let tableauValeurs = []
+            tableauValeurs.push(Math.floor(percentages[0]));
+            for(let i = 1; i <= 9; i++){
+                let y = percentages[Math.round(percentages.length / 10.0 * i)];
+                let nbDec = 0;
+                while(floorDec(y, nbDec) < tableauValeurs[0] || nbDec > 2) {
+                    nbDec += 1;
+                }
+                tableauValeurs.push(floorDec(y, nbDec));
+            }
+            return tableauValeurs;
+        };
+
+        function floorDec(val, n) {
+            let tenPowN = Math.pow(10, n);
+            return Math.floor(val * tenPowN) / tenPowN;
+        };
 
         function computeGaussScale() {
             let tableauValeurs = []
@@ -124,7 +151,7 @@
                 return;
             }
 
-           tableauValeurs = computeGaussScale();
+           tableauValeurs = computeDeciles();
 
             construireLegende(tableauValeurs, tableauCouleurs, true);
 


### PR DESCRIPTION
La carte des vaccinations a une couleur uniforme. L'échelle automatique choisie ne me semble pas adaptée. Il y a 10 couleurs dans la légende. Je propose de simplement découper l'échelle par déciles.