### PR TITLE
Suppression de la phrase des 60% d'immunité collective

### DIFF
--- a/src/VaccinTracker/dansLeMonde.php
+++ b/src/VaccinTracker/dansLeMonde.php
@@ -1,6 +1,6 @@
 <h2 style="margin-top : 80px;">Vaccination dans le monde</h2>
 
-Ce graphique présente la part de la population totale de chaque pays ayant reçu au moins une dose de vaccin. Pour la plupart des vaccins, 2 doses sont nécessaires. L'immunité collective serait atteinte à partir d'environ 60%.
+Ce graphique présente la part de la population totale de chaque pays ayant reçu au moins une dose de vaccin. Pour la plupart des vaccins, 2 doses sont nécessaires.
 <iframe src="https://ourworldindata.org/grapher/share-people-vaccinated-covid?time=latest&country=BHR~BRA~CHL~DEU~HUN~IND~ISR~RUS~SRB~TUR~GBR~USA~URY~FRA~ESP~BEL~CHE~ITA~European+Union~OWID_WRL" loading="lazy" style="width: 100%; height: 600px; border: 0px none;"></iframe>
 <br>
 <br>


### PR DESCRIPTION
Il est difficile aujourd'hui de prédire le pourcentage d'immunité collective, sans embrouiller les gens sur la différence entre le pourcentage de population totale et éligible à la vaccination.

De plus, avec Delta, les 60% ne sont clairement plus d'actualité (on serait entre 80 et 90%).

Voilà pourquoi il me semble pertinent de supprimer cette phrase.