### PR TITLE
Correction d'une faute sur la page VaccinTracker

### DIFF
--- a/src/VaccinTracker/vaccinationEHPAD.php
+++ b/src/VaccinTracker/vaccinationEHPAD.php
@@ -24,7 +24,7 @@
             </div>
         </div>
         <div class="alert alert-info">
-            Attention l'échelle de cette diffère de la carte précédente même si le code couleur utilisé est le même.
+            Attention, l'échelle de cette carte diffère de celle de la carte précédente même si le code couleur utilisé est le même.
         </div>
     </div>
     <div class="col-md-6 text-center">


### PR DESCRIPTION
Le petit avertissement en dessous de la carte "Proportion de résidents ayant reçu une dose :" dans la section "Vaccination en EHPAD" comprenait une erreur d'inattention.