### PR TITLE
VaccinTracker: add proportionVaccinesRappel parameter in the function…

### DIFF
--- a/src/VaccinTracker/vaccintrackerJs.php
+++ b/src/VaccinTracker/vaccintrackerJs.php
@@ -401,7 +401,7 @@
         date = data_france.dates[data_france.dates.length - 1]
         document.getElementById("date_maj_2").innerHTML = date.slice(8) + "/" + date.slice(5, 7);
 
-        tableVaccin(table, proportionVaccinesTotalement, proportionVaccinesPartiellement);
+        tableVaccin(table, proportionVaccinesTotalement, proportionVaccinesPartiellement, proportionVaccinesRappel);
         majValeursTable();
     }
 
@@ -410,12 +410,12 @@
         value = document.getElementById("selectTable").value;
 
         if(value=="plus12ans"){
-            tableVaccin(table, proportionVaccinesCompletementPlus12Ans, proportionVaccinesPartiellementPlus12Ans);
+            tableVaccin(table, proportionVaccinesCompletementPlus12Ans, proportionVaccinesPartiellementPlus12Ans, proportionVaccinesRappelPlus12Ans);
             for (element of document.getElementsByClassName('str-table-plus12ans')){
                 element.innerHTML = " éligibles (> 12 ans)"
             }
         } else {
-            tableVaccin(table, proportionVaccinesTotalement, proportionVaccinesPartiellement);
+            tableVaccin(table, proportionVaccinesTotalement, proportionVaccinesPartiellement, proportionVaccinesRappel);
             for (element of document.getElementsByClassName('str-table-plus12ans')){
                 element.innerHTML = ""
             }
@@ -1057,7 +1057,7 @@
         this.lineChart.update()
     }
 
-    function tableVaccin(tableElt, proportionVaccinesTotalement, proportionVaccinesPartiellement) {
+    function tableVaccin(tableElt, proportionVaccinesTotalement, proportionVaccinesPartiellement, proportionVaccinesRappel) {
         tableElt.innerHTML = "";
         let first = true;
         for (let i = 0; i < 10; i++) {


### PR DESCRIPTION
… tableVaccin

Bonjour

Sur la page vaccintracker lorsque l'on choisit "Population éligible (+12 ans)" dans le menu déroulant, les cases en vert foncé (darkdarkgreen) ne sont pas mises à jour.

Je n'ai malheureusement pas reussi à faire fonctionner le docker-compose sur mon poste et n'est donc pas pu voir le resultat.

Greg