### PR TITLE
Update dash departement (fixup 6635c2d)

### DIFF
--- a/src/DashboardDepartement/dashboardDepartementsJs.php
+++ b/src/DashboardDepartement/dashboardDepartementsJs.php
@@ -2,8 +2,8 @@
     jQuery(document).ready(function ($) {
             $('.dropdown-toggle').dropdown();
 
-            var valeurs_cas = [">", "1000", "500", "250", "150", "50"];
-            var couleurs_cas = ["black", "#3d013d", "purple", "#c80000", "#f95228", "#98ac3b"];
+            var valeurs_cas = [">", "4000", "2000", "1000", "500", "150", "50"];
+            var couleurs_cas = ["black", "#701210", "#ab1915", "#d34912", "#e29113", "#e2cb13", "#98ac3b"];
             //["3c0a09", "#aa120e", "e25e13", "#e2a213", "#e2e013", "#98ac3b"];
 
             var valeurs_n_dose1_cumsum_pop = [">", "82", "79", "76", "73", "69", "66", "60", "50", "30"];


### PR DESCRIPTION
Sur le dashboard départements, on a gardé les couleurs d'origine.
Du coup tout est en noir : https://covidtracker.fr/dashboard-departements/?dep=38.

Ce commit applique le 6635c2d mais pour les départements